### PR TITLE
add image build-time environment variable support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #Format is MAJOR . MINOR . PATCH
 
-IMAGE_VERSION=0.1.12
+IMAGE_VERSION=0.1.13
 
 
 test-build-and-package: test-source build-and-package
@@ -15,15 +15,16 @@ test-source:
 
 #Creates a test coverage file called coverage.txt.  This then opens a browser window to view the coverage
 test-coverage:
+	eval $( aws ecr get-login --region us-east-1)
 	go test ./pkg/shipyard -covermode=atomic -coverprofile=coverage.tmp
 	go test ./pkg/shipyard -covermode=atomic -coverprofile=coverage.tmp
 	echo 'mode: atomic' > coverage.out
 	tail -n +2 coverage.tmp >> coverage.out
 	go tool cover -html=coverage.out -o=coverage.html
 
-compile-linux:	
+compile-linux:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o build/shipyard .
-	
+
 build-image:
 	docker build -t thirtyx/shipyard .
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -178,6 +178,7 @@ func (server *Server) postApplication(w http.ResponseWriter, r *http.Request) {
 		RepoName:  createImage.Namespace,
 		ImageName: createImage.Application,
 		Revision:  createImage.Revision,
+		EnvVars: 	 createImage.EnvVars,
 	}
 
 	//check if the image exists, if it does, return a 409

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -38,6 +38,7 @@ type CreateImage struct {
 	Application string `schema:"application"`
 	Revision    string `schema:"revision"`
 	PublicPath  string `schema:"publicPath"`
+	EnvVars     []string `schema:"envVar"`
 }
 
 //Validate validate the application input is correct

--- a/pkg/shipyard/io.go
+++ b/pkg/shipyard/io.go
@@ -238,6 +238,10 @@ LABEL ` + TAG_APPLICATION + `={{.ImageName}}
 LABEL ` + TAG_REVISION + `={{.Revision}}
 
 CMD ["npm", "start"]
+
+{{range .EnvVars}}
+ENV {{.}}
+{{end}}
 `
 
 //constant that's initialized below.  Constants must only be primitive types

--- a/pkg/shipyard/types.go
+++ b/pkg/shipyard/types.go
@@ -11,6 +11,7 @@ type DockerInfo struct {
 	RepoName  string
 	ImageName string
 	Revision  string
+	EnvVars   []string
 }
 
 //GetImageName generate an image of the format {RepoName}/{ImageName}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -50,6 +50,12 @@ paths:
           description: The public path of the application in the format of [PORT]:[URL]. For example, 8080:/ or 9000:/foo/bar
           required: true
           type: string
+        - name: envVar
+          in: formData
+          description: An optional array of environment variables for the image
+          type: array
+          items:
+            type: string
   '/namespaces':
     get:
       description: Get all namespaces


### PR DESCRIPTION
Add support for an optional environment variables array at image creation/build time. 

An example cURL looks like this:
```sh
curl -H "Authorization: Bearer $APIGEE_TOKEN" -X POST \
http://localhost:5280/beeswax/images/api/v1/builds/ -F "namespace=$APIGEE_ORG" \
-F "application=example" -F "revision=0" -F 'publicPath=9000:/example' \
-F "file=@example-app.zip" -F "envVar=NAME1=VAL1" -F "envVar=NAME2=\"STRINGVAL\""
```

Any number of `envVar` pairs can be included.

Fixes #37 